### PR TITLE
[STR-506] Add bypassDeviceCheck option

### DIFF
--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -51,7 +51,7 @@ namespace StringSDK
             }
             try
             {
-                var bypassDevice = loginOptions?.bypassDeviceCheck || false ? "?bypassDevice=true" : "";
+                var bypassDevice = loginOptions?.bypassDeviceCheck ?? false ? "?bypassDevice=true" : "";
                 return await apiClient.Post<LoginResponse>($"/login/sign{bypassDevice}", loginRequest);
             }
             catch // (Exception e)

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -43,7 +43,7 @@ namespace StringSDK
             return await apiClient.Get<LoginPayload>($"/login?walletAddress={walletAddr}");
         }
 
-        public static async UniTask<LoginResponse> Login(LoginRequest loginRequest, CancellationToken token = default)
+        public static async UniTask<LoginResponse> Login(LoginRequest loginRequest, LoginOptions loginOptions = default, CancellationToken token = default)
         {
             if (!WebEventManager.FingerprintAvailable())
             {
@@ -51,7 +51,8 @@ namespace StringSDK
             }
             try
             {
-                return await apiClient.Post<LoginResponse>($"/login/sign", loginRequest);
+                var bypassDevice = loginOptions?.bypassDeviceCheck ? "?bypassDevice=true" : "";
+                return await apiClient.Post<LoginResponse>($"/login/sign{bypassDevice}", loginRequest);
             }
             catch // (Exception e)
             {

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -51,7 +51,7 @@ namespace StringSDK
             }
             try
             {
-                var bypassDevice = loginOptions?.bypassDeviceCheck ? "?bypassDevice=true" : "";
+                var bypassDevice = loginOptions?.bypassDeviceCheck || false ? "?bypassDevice=true" : "";
                 return await apiClient.Post<LoginResponse>($"/login/sign{bypassDevice}", loginRequest);
             }
             catch // (Exception e)

--- a/Runtime/Types.cs
+++ b/Runtime/Types.cs
@@ -109,6 +109,22 @@ namespace StringSDK
     }
 
     [Serializable]
+    public class LoginOptions
+    {
+        public bool bypassDeviceCheck;
+
+        public LoginOptions(bool bypassDeviceCheck = false)
+        {
+            this.bypassDeviceCheck = bypassDeviceCheck;
+        }
+
+        public override string ToString()
+        {
+            return JsonUtility.ToJson(this);
+        }
+    }
+
+    [Serializable]
     public class Fingerprint
     {
         public string visitorId;


### PR DESCRIPTION
Create a String User

In _unity-sdk/Runtime/WebEventManager.cs:87_:
```
  FingerprintVisitorId = "RgauFjjfEjKk2QIxwMqt";
  FingerprintRequestId = "1680123007076.cdJGvH";
```

At _unity-demo/Assets/GameLogicBehavior.cs:214_ put:
```
        LoginOptions options = new LoginOptions(
            bypassDeviceCheck: true
        );

        var response = await StringXYZ.Login(login, options);
```

Should log you in without needing to verify device

