### PR TITLE
[STR-530] Allow platform to set environment

### DIFF
--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -46,12 +46,13 @@ namespace StringSDK
 
         public static EnvironmentType Environment
         {
-            get => Environment;
+            get => environment;
             set {
-                Environment = value;
+                environment = value;
                 apiClient.BaseUrl = GetEnvironmentUrl(value);
             }
         }
+        static EnvironmentType environment;
 
         // Headers
         public static string ApiKey

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -15,6 +15,7 @@ namespace StringSDK
         public const string PROD_API_URL = "https://api.string-api.xyz";
         public const string SANDBOX_API_URL = "https://api.sandbox.string-api.xyz";
         public const string DEV_API_URL = "https://string-api.dev.string-api.xyz";
+        // TODO: Remove exposed local env before product launch
         public const string LOCAL_API_URL = "http://localhost:5555";
     }
 

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -10,6 +10,8 @@ namespace StringSDK
 {
     public static class Constants
     {
+        public const string DEFAULT_ENV = "https://api.sandbox.string-api.xyz";
+
         public const string PROD_API_URL = "https://api.string-api.xyz";
         public const string SANDBOX_API_URL = "https://api.sandbox.string-api.xyz";
         public const string DEV_API_URL = "https://string-api.dev.string-api.xyz";
@@ -32,7 +34,7 @@ namespace StringSDK
                     EnvironmentType.SANDBOX => Constants.SANDBOX_API_URL,
                     EnvironmentType.DEV => Constants.DEV_API_URL,
                     EnvironmentType.LOCAL => Constants.LOCAL_API_URL,
-                    _ => Constants.LOCAL_API_URL,
+                    _ => Constants.DEFAULT_ENV,
                 };
 
                 apiClient.BaseUrl = basePath;
@@ -64,7 +66,7 @@ namespace StringSDK
         static StringXYZ()
         {
             apiClient = new ApiClient();
-            apiClient.BaseUrl = Constants.LOCAL_API_URL;
+            apiClient.BaseUrl = Constants.DEFAULT_ENV;
         }
 
         // Methods

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -10,13 +10,42 @@ namespace StringSDK
 {
     public static class Constants
     {
-        public const string api_base_url = "http://localhost:5555";
+        public const string PROD_API_URL = "https://api.string-api.xyz";
+        public const string SANDBOX_API_URL = "https://api.sandbox.string-api.xyz";
+        public const string DEV_API_URL = "https://string-api.dev.string-api.xyz";
+        public const string LOCAL_API_URL = "http://localhost:5555";
     }
 
     public static class StringXYZ
     {
         // API Client
         static ApiClient apiClient;
+
+        public static EnvironmentType Environment
+        {
+            get => Environment;
+            set {
+                Environment = value;
+                var basePath = value switch 
+                {
+                    EnvironmentType.PROD => Constants.PROD_API_URL,
+                    EnvironmentType.SANDBOX => Constants.SANDBOX_API_URL,
+                    EnvironmentType.DEV => Constants.DEV_API_URL,
+                    EnvironmentType.LOCAL => Constants.LOCAL_API_URL,
+                    _ => Constants.LOCAL_API_URL,
+                };
+
+                apiClient.BaseUrl = basePath;
+            }
+        }
+
+        public enum EnvironmentType
+        {
+            PROD,
+            SANDBOX,
+            DEV,
+            LOCAL
+        }
 
         // Headers
         public static string ApiKey
@@ -34,7 +63,8 @@ namespace StringSDK
         // Constructor
         static StringXYZ()
         {
-            apiClient = new ApiClient(Constants.api_base_url);
+            apiClient = new ApiClient();
+            apiClient.BaseUrl = Constants.LOCAL_API_URL;
         }
 
         // Methods

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -23,30 +23,33 @@ namespace StringSDK
         // API Client
         static ApiClient apiClient;
 
-        public static EnvironmentType Environment
-        {
-            get => Environment;
-            set {
-                Environment = value;
-                var basePath = value switch 
-                {
-                    EnvironmentType.PROD => Constants.PROD_API_URL,
-                    EnvironmentType.SANDBOX => Constants.SANDBOX_API_URL,
-                    EnvironmentType.DEV => Constants.DEV_API_URL,
-                    EnvironmentType.LOCAL => Constants.LOCAL_API_URL,
-                    _ => Constants.DEFAULT_ENV,
-                };
-
-                apiClient.BaseUrl = basePath;
-            }
-        }
-
         public enum EnvironmentType
         {
             PROD,
             SANDBOX,
             DEV,
             LOCAL
+        }
+
+        static string GetEnvironmentUrl(EnvironmentType env)
+        {
+            return env switch
+            {
+                EnvironmentType.PROD => Constants.PROD_API_URL,
+                EnvironmentType.SANDBOX => Constants.SANDBOX_API_URL,
+                EnvironmentType.DEV => Constants.DEV_API_URL,
+                EnvironmentType.LOCAL => Constants.LOCAL_API_URL,
+                _ => Constants.DEFAULT_ENV,
+            };
+        }
+
+        public static EnvironmentType Environment
+        {
+            get => Environment;
+            set {
+                Environment = value;
+                apiClient.BaseUrl = GetEnvironmentUrl(value);
+            }
         }
 
         // Headers

--- a/Runtime/ApiClient.cs
+++ b/Runtime/ApiClient.cs
@@ -19,9 +19,8 @@ namespace StringSDK
 		/// </summary>
 		/// <param name="baseUrl">base url for requests, e.g. https://api.example.com</param>
 		/// <param name="basicAuth">plaintext string to be base64 encoded as HTTP basic auth</param>
-		public ApiClient(string baseUrl, string basicAuth = null)
+		public ApiClient(string basicAuth = null)
 		{
-			this.baseUrl = baseUrl;
 			this.BasicAuth = basicAuth;
 		}
 
@@ -52,7 +51,12 @@ namespace StringSDK
 		/// <summary>
 		/// baseUrl defines the base url to use with each path
 		/// </summary>
-		public string baseUrl;
+		internal string BaseUrl
+		{
+			get => baseUrl;
+			set => baseUrl = value;
+		}
+		string baseUrl;
 
 		/// <summary>
 		/// Sends an HTTP GET request to the given path


### PR DESCRIPTION
In _unity-demo/Assets/GameLogicBehavior.cs:51_
```
        StringXYZ.ApiKey = "str...";
        StringXYZ.Environment = StringXYZ.EnvironmentType.SANDBOX;
```

It defaults to local but it can also be PROD, SANDBOX, DEV, or LOCAL

**Criteria:** All envs (save untestable prod) with their respective api keys work as expected 