### PR TITLE
task/sean/str-557

### DIFF
--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -46,7 +46,7 @@ namespace StringSDK
             return await apiClient.Get<LoginPayload>($"/login?walletAddress={walletAddr}");
         }
 
-        public static async UniTask<LoginResponse> Login(LoginRequest loginRequest, LoginOptions loginOptions = default, CancellationToken token = default)
+        public static async UniTask<LoginResponse> Login(LoginRequest loginRequest, bool bypassDeviceCheck = false, CancellationToken token = default)
         {
             if (!WebEventManager.FingerprintAvailable())
             {
@@ -54,8 +54,9 @@ namespace StringSDK
             }
             try
             {
-                var bypassDevice = loginOptions?.bypassDeviceCheck ?? false ? "?bypassDevice=true" : "";
-                return await apiClient.Post<LoginResponse>($"/login/sign{bypassDevice}", loginRequest);
+                string bypass = "false";
+                if (bypassDeviceCheck) bypass = "true";
+                return await apiClient.Post<LoginResponse>($"/login/sign?bypassDevice={bypass}", loginRequest);
             }
             catch // (Exception e)
             {

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -48,7 +48,10 @@ namespace StringSDK
 
         public static async UniTask<LoginResponse> Login(LoginRequest loginRequest, bool bypassDeviceCheck = false, CancellationToken token = default)
         {
+            // Update fingerprint data
             await Util.WaitUntil(() => WebEventManager.FingerprintAvailable());
+            loginRequest.fingerprint.visitorId = WebEventManager.FingerprintVisitorId;
+            loginRequest.fingerprint.requestId = WebEventManager.FingerprintRequestId;
             try {
                 string bypass = "false";
                 if (bypassDeviceCheck) bypass = "true";

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -48,22 +48,12 @@ namespace StringSDK
 
         public static async UniTask<LoginResponse> Login(LoginRequest loginRequest, bool bypassDeviceCheck = false, CancellationToken token = default)
         {
-            if (!WebEventManager.FingerprintAvailable())
-            {
-                Debug.Log("WARNING: Fingerprint Data Not Yet Available");
-            }
-            try
-            {
+            await Util.WaitUntil(() => WebEventManager.FingerprintAvailable());
+            try {
                 string bypass = "false";
                 if (bypassDeviceCheck) bypass = "true";
                 return await apiClient.Post<LoginResponse>($"/login/sign?bypassDevice={bypass}", loginRequest);
-            }
-            catch // (Exception e)
-            {
-                // Unsure how to check for 400 Bad response without parsing Exception string
-                // Skipping for now
-                // TODO: Parse exception for status code 400 before Creating user
-                // If the status is not 400, throw error up the stack
+            } catch { // TODO: Replace HTTP Client so that we can respond differently based on HTTP Status!
                 return await CreateUser(loginRequest);
             }
         }

--- a/Runtime/Types.cs
+++ b/Runtime/Types.cs
@@ -150,22 +150,6 @@ namespace StringSDK
     }
 
     [Serializable]
-    public class LoginOptions
-    {
-        public bool bypassDeviceCheck;
-
-        public LoginOptions(bool bypassDeviceCheck = false)
-        {
-            this.bypassDeviceCheck = bypassDeviceCheck;
-        }
-
-        public override string ToString()
-        {
-            return JsonUtility.ToJson(this);
-        }
-    }
-
-    [Serializable]
     public class Fingerprint
     {
         public string visitorId;

--- a/Runtime/Types.cs
+++ b/Runtime/Types.cs
@@ -109,22 +109,6 @@ namespace StringSDK
     }
 
     [Serializable]
-    public class LoginOptions
-    {
-        public bool bypassDeviceCheck;
-
-        public LoginOptions(bool bypassDeviceCheck = false)
-        {
-            this.bypassDeviceCheck = bypassDeviceCheck;
-        }
-
-        public override string ToString()
-        {
-            return JsonUtility.ToJson(this);
-        }
-    }
-
-    [Serializable]
     public class Fingerprint
     {
         public string visitorId;

--- a/Runtime/Util.cs
+++ b/Runtime/Util.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace StringSDK
+{
+    // Usage: await Util.WaitUntil(() => condition == true);
+    public static class Util
+    {
+        public static async Task WaitUntil(Func<bool> condition, int frequency = 25, int timeout = -1)
+        {
+            var waitTask = Task.Run(async () =>
+            {
+                while (!condition()) await Task.Delay(frequency);
+            });
+
+            if (waitTask != await Task.WhenAny(waitTask, 
+                    Task.Delay(timeout))) 
+                throw new TimeoutException();
+        }
+    }
+}

--- a/Runtime/Util.cs.meta
+++ b/Runtime/Util.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f71cee86f3e184b0fb376a13d9b8321c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/WebEventManager.cs
+++ b/Runtime/WebEventManager.cs
@@ -134,7 +134,7 @@ namespace StringSDK
 
         public static bool FingerprintAvailable()
         {
-            return (FingerprintVisitorId != "" && FingerprintRequestId != "");
+            return (FingerprintVisitorId != null && FingerprintRequestId != null);
         }
     }
 }


### PR DESCRIPTION
Removed LoginOptions serialized type because it's never sent as a payload to the API.

Otherwise I was not able to repro the bug described in Jira:
https://stringxyz.atlassian.net/browse/STR-557?atlOrigin=eyJpIjoiNzE2YzQyZDkyMzY1NDY4MzlmNGQxYzUyYWFkMjg5NTYiLCJwIjoiaiJ9

When I click Login/Create on a fresh docker reset, it Creates the account the first time without any issues.  Then on subsequent attempts, it just logs in.

FYI Bypass device verification defaults to FALSE, so if you try to log in before the Fingerprint data gets returned you might get an error.

EDIT: We found that the issue was due to Fingerprint Data not being available.  I've added some logic which waits until it's available before logging in.

We will need to create a new task in JIRA to get / create a new HTTP library so that we can deal with various HTTP responses without panicking. Eek.