### PR TITLE
Expose HttpResponse for endpoints which do not return an object

### DIFF
--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -100,7 +100,7 @@ namespace StringSDK
 
         public static async UniTask<HttpResponse> Logout(CancellationToken token = default)
         {
-            var result = await apiClient.Post($"/login/logout");
+            HttpResponse result = await apiClient.Post(path: $"/login/logout", body: null);
             if (!result.IsSuccess)
             {
                 Debug.Log($"Logout returned error {result.errorMsg}");

--- a/Runtime/API.cs
+++ b/Runtime/API.cs
@@ -90,22 +90,22 @@ namespace StringSDK
 
         public static async UniTask<HttpResponse> RequestEmailAuth(string emailAddr, string userId, CancellationToken token = default)
         {
-            var result = await apiClient.Get<HttpResponse>($"/users/{userId}/verify-email?email={emailAddr}");
+            var result = await apiClient.Get($"/users/{userId}/verify-email?email={emailAddr}");
             if (!result.IsSuccess)
             {
                 Debug.Log($"RequestEmailAuth returned error {result.errorMsg}");
             }
-            return result.body;
+            return result;
         }
 
         public static async UniTask<HttpResponse> Logout(CancellationToken token = default)
         {
-            var result = await apiClient.Post<HttpResponse>($"/login/logout");
+            var result = await apiClient.Post($"/login/logout");
             if (!result.IsSuccess)
             {
                 Debug.Log($"Logout returned error {result.errorMsg}");
             }
-            return result.body;
+            return result;
         }
 
         public static async UniTask<User> SetUserName(UserNameRequest userNameRequest, string userId, CancellationToken token = default)

--- a/Runtime/HttpResponse.cs
+++ b/Runtime/HttpResponse.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace StringSDK
 {
@@ -8,6 +9,8 @@ namespace StringSDK
 		public bool IsSuccess => 200 <= status && status <= 299;
 		public Dictionary<string, string> headers;
 		public string errorMsg;
+
+		public override string ToString() => JsonUtility.ToJson(this);
 	}
 
 	public struct HttpResponseObject<T> {
@@ -16,5 +19,7 @@ namespace StringSDK
 		public bool IsSuccess => 200 <= status && status <= 299;
 		public Dictionary<string, string> headers;
 		public string errorMsg;
+
+		public override string ToString() => JsonUtility.ToJson(this);
 	}
 }


### PR DESCRIPTION
I am writing tests right now which look at the status of endpoints which do not return any specific object, notable Request Email Authentication and Log Out.  This PR returns the base HttpResponse for those endpoints.

In order to test this PR, you can run the tests for those two endpoints in the Unity Demo once the PR is up.